### PR TITLE
Don't terminate immediately after opening a URL, because that causes successive opens to fail.

### DIFF
--- a/Safari Private/App.swift
+++ b/Safari Private/App.swift
@@ -10,12 +10,24 @@ struct AppMain: App {
 }
 
 private final class AppDelegate: NSObject, NSApplicationDelegate {
+	var count: Int = 0
+
+	func terminateIfNecessary() {
+		if (count > 0) {
+			count -= 1
+			delay(seconds: 10) {
+				self.terminateIfNecessary()
+			}
+		} else {
+			NSApp.terminate(nil)
+		}
+	}
+
 	func applicationDidFinishLaunching(_ notification: Notification) {
 		_ = Permissions.Accessibility.requestAccess()
 
-		delay(seconds: 10) {
-			NSApp.terminate(nil)
-		}
+		count += 1
+		terminateIfNecessary()
 	}
 
 	func application(_ application: NSApplication, open urls: [URL]) {
@@ -27,7 +39,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
 			return
 		}
 
+		count += 1
 		openPrivateSafariWindow(with: urls)
-		NSApp.terminate(nil)
+		terminateIfNecessary()
 	}
 }


### PR DESCRIPTION
For example, from Terminal app:
open -a "Safari Private" "https://www.apple.com"; open -a "Safari Private" "https://www.cnn.com"

I don't write much Swift, and this code may be ugly, so feel free to rewrite it. I think you get the gist, though, which is to delay terminating the app for a bit each time that a URL is opened.